### PR TITLE
Add synchronous param to mlx spin up

### DIFF
--- a/components/mlx90393/sensor.py
+++ b/components/mlx90393/sensor.py
@@ -140,6 +140,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required("woxy_threshold"): cv.templatable(cv.int_),
         }
     ),
+    synchronous=True,
 )
 async def mlx90393_enable_woc_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])


### PR DESCRIPTION
test to remove warning from c6 spin up of mlx and maybe let woc work … in latest esphome.  Worked fine in all tests, removed warning.  Promoting to main.